### PR TITLE
Fix default dtype

### DIFF
--- a/mpnum/_testing.py
+++ b/mpnum/_testing.py
@@ -25,6 +25,7 @@ def assert_mpa_identical(mpa1, mpa2, decimal=np.infty):
     """
     assert len(mpa1) == len(mpa2)
     assert mpa1.normal_form == mpa2.normal_form
+    assert mpa1.dtype == mpa2.dtype
 
     for i, lten1, lten2 in zip(it.count(), mpa1.lt, mpa2.lt):
         if decimal is np.infty:

--- a/mpnum/factory.py
+++ b/mpnum/factory.py
@@ -19,8 +19,7 @@ from .mpstruct import LocalTensors
 
 
 __all__ = ['eye', 'random_local_ham', 'random_mpa', 'random_mpdo',
-           'random_mps', 'random_mpo', 'random_op', 'random_state',
-           'random_vec', 'zero', 'diagonal_mpa']
+           'random_mps', 'random_mpo', 'zero', 'diagonal_mpa']
 
 
 def _zrandn(shape, randstate=None):
@@ -48,7 +47,7 @@ def _randn(shape, randstate=None):
 _randfuncs = {np.float_: _randn, np.complex_: _zrandn}
 
 
-def random_vec(sites, ldim, randstate=None, dtype=np.complex_):
+def _random_vec(sites, ldim, randstate=None, dtype=np.complex_):
     """Returns a random complex vector (normalized to ||x||_2 = 1) of shape
     (ldim,) * sites, i.e. a pure state with local dimension `ldim` living on
     `sites` sites.
@@ -58,7 +57,7 @@ def random_vec(sites, ldim, randstate=None, dtype=np.complex_):
     :param randstate: numpy.random.RandomState instance or None
     :returns: numpy.ndarray of shape (ldim,) * sites
 
-    >>> psi = random_vec(5, 2); psi.shape
+    >>> psi = _random_vec(5, 2); psi.shape
     (2, 2, 2, 2, 2)
     >>> np.abs(np.vdot(psi, psi) - 1) < 1e-6
     True
@@ -69,7 +68,7 @@ def random_vec(sites, ldim, randstate=None, dtype=np.complex_):
     return psi
 
 
-def random_op(sites, ldim, hermitian=False, normalized=False, randstate=None,
+def _random_op(sites, ldim, hermitian=False, normalized=False, randstate=None,
               dtype=np.complex_):
     """Returns a random operator  of shape (ldim,ldim) * sites with local
     dimension `ldim` living on `sites` sites in global form.
@@ -81,7 +80,7 @@ def random_op(sites, ldim, hermitian=False, normalized=False, randstate=None,
     :param randstate: numpy.random.RandomState instance or None
     :returns: numpy.ndarray of shape (ldim,ldim) * sites
 
-    >>> A = random_op(3, 2); A.shape
+    >>> A = _random_op(3, 2); A.shape
     (2, 2, 2, 2, 2, 2)
     """
     op = _randfuncs[dtype]((ldim**sites,) * 2, randstate=randstate)
@@ -92,7 +91,7 @@ def random_op(sites, ldim, hermitian=False, normalized=False, randstate=None,
     return op.reshape((ldim,) * 2 * sites)
 
 
-def random_state(sites, ldim, randstate=None):
+def _random_state(sites, ldim, randstate=None):
     """Returns a random positive semidefinite operator of shape (ldim, ldim) *
     sites normalized to Tr rho = 1, i.e. a mixed state with local dimension
     `ldim` living on `sites` sites. Note that the returned state is positive
@@ -105,7 +104,7 @@ def random_state(sites, ldim, randstate=None):
     :returns: numpy.ndarray of shape (ldim, ldim) * sites
 
     >>> from numpy.linalg import eigvalsh
-    >>> rho = random_state(3, 2).reshape((2**3, 2**3))
+    >>> rho = _random_state(3, 2).reshape((2**3, 2**3))
     >>> all(eigvalsh(rho) >= 0)
     True
     >>> np.abs(np.trace(rho) - 1) < 1e-6
@@ -396,7 +395,7 @@ def random_local_ham(sites, ldim=2, intlen=2, randstate=None):
 
     """
     def get_local_ham():
-        op = random_op(intlen, ldim, hermitian=True, normalized=True)
+        op = _random_op(intlen, ldim, hermitian=True, normalized=True)
         op = global_to_local(op, sites=intlen)
         return mp.MPArray.from_array(op, plegs=2)
 

--- a/mpnum/factory.py
+++ b/mpnum/factory.py
@@ -117,6 +117,10 @@ def _random_state(sites, ldim, randstate=None):
     return rho.reshape((ldim,) * 2 * sites)
 
 
+####################################
+#  Factory functions for MPArrays  #
+####################################
+
 def _generate(sites, ldim, bdim, func, force_bdim):
     """Returns a matrix product operator with identical number and dimensions
     of the physical legs. The local tensors are generated using `func`
@@ -171,7 +175,7 @@ def _generate(sites, ldim, bdim, func, force_bdim):
 
 
 def random_mpa(sites, ldim, bdim, randstate=None, normalized=False,
-               force_bdim=False, dtype=np.complex_):
+               force_bdim=False, dtype=np.float_):
     """Returns a MPA with randomly choosen local tensors
 
     :param sites: Number of sites
@@ -311,7 +315,7 @@ def random_mpo(sites, ldim, bdim, randstate=None, hermitian=False,
 
     """
     mpo = random_mpa(sites, (ldim,) * 2, bdim, randstate=randstate,
-                     force_bdim=force_bdim)
+                     force_bdim=force_bdim, dtype=np.complex_)
 
     if hermitian:
         # make mpa Herimitan in place, without increasing bond dimension:
@@ -347,7 +351,7 @@ def random_mps(sites, ldim, bdim, randstate=None, force_bdim=False):
 
     """
     return random_mpa(sites, ldim, bdim, normalized=True, randstate=randstate,
-                      force_bdim=force_bdim)
+                      force_bdim=force_bdim, dtype=np.complex_)
 
 
 def random_mpdo(sites, ldim, bdim, randstate=np.random):

--- a/mpnum/linalg.py
+++ b/mpnum/linalg.py
@@ -415,8 +415,10 @@ def mineig(mpo,
         if startvec_bonddim == 1:
             raise ValueError('startvec_bonddim must be at least 2')
 
+        # FIXME Can we choose dtype as mpo.dtype? If so, also adapt mineig_sum
         startvec = random_mpa(nr_sites, pdims, startvec_bonddim,
-                              randstate=randstate)
+                              randstate=randstate, dtype=np.complex_)
+        startvec.normalize(right=1)
         startvec /= mp.norm(startvec)
     else:
         # Do not modify the `startvec` argument.
@@ -538,7 +540,8 @@ def mineig_sum(mpas,
             raise ValueError('startvec_bonddim must be at least 2')
 
         startvec = random_mpa(nr_sites, pdims, startvec_bonddim,
-                              randstate=randstate)
+                              randstate=randstate, dtype=np.complex_)
+        startvec.normalize(right=1)
         startvec /= mp.norm(startvec)
     else:
         # Do not modify the `startvec` argument.

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -79,8 +79,8 @@ def test_mineig_sum_minimize_sites(nr_sites, local_dim, bond_dim, rgen):
     mpo = factory.random_mpo(nr_sites, local_dim, bond_dim, randstate=rgen,
                              hermitian=True, normalized=True)
     mpo.normalize()
-    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen)
-    mps /= mp.norm(mps)
+    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen,
+                             dtype=np.complex_, normalized=True)
     mpas = [mpo, mps]
 
     vec = mps.to_array().ravel()
@@ -102,7 +102,7 @@ def test_mineig_sum_minimize_sites(nr_sites, local_dim, bond_dim, rgen):
     assert_almost_equal(abs(overlap), 1)
 
 
-BENCHMARK_MINEIG_PARAMS = [(20, 2, 12, 12)] 
+BENCHMARK_MINEIG_PARAMS = [(20, 2, 12, 12)]
 
 @pt.mark.benchmark(group='mineig_sum', min_rounds=2)
 @pt.mark.parametrize(
@@ -112,8 +112,8 @@ def test_mineig_benchmark(
     mpo = factory.random_mpo(nr_sites, local_dim, bond_dim, randstate=rgen,
                              hermitian=True, normalized=True)
     mpo.normalize()
-    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen)
-    mps /= mp.norm(mps)
+    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen,
+                             dtype=np.complex_, normalized=True)
     mpo = mpo + mp.mps_to_mpo(mps)
 
     benchmark(
@@ -131,8 +131,8 @@ def test_mineig_sum_benchmark(
     mpo = factory.random_mpo(nr_sites, local_dim, bond_dim, randstate=rgen,
                              hermitian=True, normalized=True)
     mpo.normalize()
-    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen)
-    mps /= mp.norm(mps)
+    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen,
+                             dtype=np.complex_, normalized=True)
 
     benchmark(
         mpnum.linalg.mineig_sum,

--- a/tests/mparray_test.py
+++ b/tests/mparray_test.py
@@ -408,16 +408,13 @@ def test_inner_mat(nr_sites, local_dim, bond_dim, rgen, dtype):
 @pt.mark.parametrize('nr_sites, local_dim, bond_dim', MP_TEST_PARAMETERS)
 def test_sandwich(nr_sites, local_dim, bond_dim, rgen, dtype):
     mps = factory.random_mpa(nr_sites, local_dim, bond_dim,
-                             randstate=rgen, dtype=dtype)
+                             randstate=rgen, dtype=dtype, normalized=True)
     mps2 = factory.random_mpa(nr_sites, local_dim, bond_dim,
-                              randstate=rgen, dtype=dtype)
+                              randstate=rgen, dtype=dtype, normalized=True)
     mpo = factory.random_mpa(nr_sites, [local_dim] * 2, bond_dim,
                              randstate=rgen, dtype=dtype)
-    mps /= mp.norm(mps)
-    mps2 /= mp.norm(mps2)
     mpo.normalize()
     mpo /= mp.trace(mpo)
-    mpo.normalize()
 
     vec = mps.to_array().ravel()
     op = mpo.to_array_global().reshape([local_dim**nr_sites] * 2)
@@ -1081,8 +1078,8 @@ def test_singularvals(nr_sites, local_dim, bond_dim, dtype, rgen):
 
 @pt.mark.parametrize('nr_sites, local_dim, bond_dim', MP_TEST_PARAMETERS)
 def test_pad_bdim(nr_sites, local_dim, bond_dim, rgen):
-    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen)
-    mps /= mp.norm(mps)
+    mps = factory.random_mpa(nr_sites, local_dim, bond_dim, randstate=rgen,
+                             normalized=True)
     mps2 = mps.pad_bdim(2 * bond_dim)
     assert mps2.bdims == tuple(min(d, 2 * bond_dim) for d in mp.full_bdim(mps.pdims))
     assert_almost_equal(mp.normdist(mps, mps2), 0.0)

--- a/tests/mparray_test.py
+++ b/tests/mparray_test.py
@@ -47,12 +47,12 @@ def update_copy_of(target, newvals):
 @pt.mark.parametrize('dtype', MP_TEST_DTYPES)
 @pt.mark.parametrize('nr_sites, local_dim, _', MP_TEST_PARAMETERS)
 def test_from_full(nr_sites, local_dim, _, rgen, dtype):
-    psi = factory.random_vec(nr_sites, local_dim, randstate=rgen, dtype=dtype)
+    psi = factory._random_vec(nr_sites, local_dim, randstate=rgen, dtype=dtype)
     mps = mp.MPArray.from_array(psi, 1)
     assert_array_almost_equal(psi, mps.to_array())
     assert mps.dtype == dtype
 
-    op = factory.random_op(nr_sites, local_dim, randstate=rgen, dtype=dtype)
+    op = factory._random_op(nr_sites, local_dim, randstate=rgen, dtype=dtype)
     mpo = mp.MPArray.from_array(op, 2)
     assert_array_almost_equal(op, mpo.to_array())
     assert mpo.dtype == dtype
@@ -82,7 +82,7 @@ def test_from_kron(nr_sites, local_dim, bond_dim, dtype):
 @pt.mark.parametrize('dtype', MP_TEST_DTYPES)
 @pt.mark.parametrize('nr_sites, local_dim, _', MP_TEST_PARAMETERS)
 def test_conjugations(nr_sites, local_dim, _, rgen, dtype):
-    op = factory.random_op(nr_sites, local_dim, randstate=rgen, dtype=dtype)
+    op = factory._random_op(nr_sites, local_dim, randstate=rgen, dtype=dtype)
     mpo = mp.MPArray.from_array(op, 2)
     assert_array_almost_equal(np.conj(op), mpo.conj().to_array())
     assert mpo.conj().dtype == dtype
@@ -95,7 +95,7 @@ def test_conjugations(nr_sites, local_dim, _, rgen, dtype):
 @pt.mark.parametrize('dtype', MP_TEST_DTYPES)
 @pt.mark.parametrize('nr_sites, local_dim, _', MP_TEST_PARAMETERS)
 def test_transpose(nr_sites, local_dim, _, rgen, dtype):
-    op = factory.random_op(nr_sites, local_dim, randstate=rgen, dtype=dtype)
+    op = factory._random_op(nr_sites, local_dim, randstate=rgen, dtype=dtype)
     mpo = mp.MPArray.from_array(global_to_local(op, nr_sites), 2)
 
     opT = op.reshape((local_dim**nr_sites,) * 2).T \
@@ -904,7 +904,7 @@ def test_split(nr_sites, local_dim, bond_dim, rgen):
 ###############################################################################
 @pt.mark.parametrize('nr_sites, local_dim, _', MP_TEST_PARAMETERS)
 def test_normalization_from_full(nr_sites, local_dim, _, rgen):
-    op = factory.random_op(nr_sites, local_dim, randstate=rgen)
+    op = factory._random_op(nr_sites, local_dim, randstate=rgen)
     mpo = mp.MPArray.from_array(op, 2)
     assert_correct_normalization(mpo, nr_sites - 1, nr_sites)
 

--- a/tests/povm_test.py
+++ b/tests/povm_test.py
@@ -119,10 +119,9 @@ def test_povm_ic_mpa(nr_sites, local_dim, bond_dim, rgen):
     # Check linear inversion for a particular example MPA.
     # Linear inversion works for arbitrary matrices, not only for states,
     # so we test it for an arbitrary MPA.
-    mpa = factory.random_mpa(nr_sites, local_dim**2, bond_dim,
-                             dtype=np.complex_, randstate=rgen)
     # Normalize, otherwise the absolute error check below will not work.
-    mpa /= mp.norm(mpa)
+    mpa = factory.random_mpa(nr_sites, local_dim**2, bond_dim,
+                             dtype=np.complex_, randstate=rgen, normalized=True)
     probabs = mp.dot(probab_map, mpa)
     recons = mp.dot(inv_map, probabs)
     assert mp.norm(recons - mpa) < 1e-6
@@ -262,8 +261,7 @@ def test_mppovm_pmf_as_array_pmps(
         mppaulis = povm.MPPovm.from_local_povm(povm.pauli_povm(pdims), width)
     mppaulis = mppaulis.embed(nr_sites, startsite, pdims)
     pmps = factory.random_mpa(nr_sites, local_dim, bond_dim,
-                              dtype=np.complex_, randstate=rgen)
-    pmps /= mp.norm(pmps)
+                              dtype=np.complex_, randstate=rgen, normalized=True)
     rho = mpsmpo.pmps_to_mpo(pmps)
     expect_rho = mppaulis.pmf_as_array(rho, 'mpdo')
 
@@ -282,8 +280,7 @@ def test_mppovm_pmf_as_array_pmps_benchmark(
     mpp_y = povm.MPPovm.from_local_povm(pauli_y, width) \
                        .embed(nr_sites, startsite, local_dim)
     pmps = factory.random_mpa(nr_sites, (local_dim, local_dim), bond_dim,
-                              dtype=np.complex_, randstate=rgen)
-    pmps /= mp.norm(pmps)
+                              dtype=np.complex_, randstate=rgen, normalized=True)
     benchmark(lambda: mpp_y.pmf_as_array(pmps, 'pmps', impl=impl))
 
 

--- a/tests/povm_test.py
+++ b/tests/povm_test.py
@@ -119,7 +119,8 @@ def test_povm_ic_mpa(nr_sites, local_dim, bond_dim, rgen):
     # Check linear inversion for a particular example MPA.
     # Linear inversion works for arbitrary matrices, not only for states,
     # so we test it for an arbitrary MPA.
-    mpa = factory.random_mpa(nr_sites, local_dim**2, bond_dim, randstate=rgen)
+    mpa = factory.random_mpa(nr_sites, local_dim**2, bond_dim,
+                             dtype=np.complex_, randstate=rgen)
     # Normalize, otherwise the absolute error check below will not work.
     mpa /= mp.norm(mpa)
     probabs = mp.dot(probab_map, mpa)
@@ -146,7 +147,7 @@ def test_mppovm_expectation(nr_sites, width, local_dim, bond_dim, nopovm, rgen):
     pmap = nopovm.probability_map
     mpnopovm = povm.MPPovm.from_local_povm(nopovm, width)
     # Use a random MPO rho for testing (instead of a positive MPO).
-    rho = factory.random_mpa(nr_sites, (local_dim,) * 2, bond_dim, rgen)
+    rho = factory.random_mpo(nr_sites, local_dim, bond_dim, rgen)
     reductions = mpsmpo.reductions_mpo(rho, width)
     # Compute expectation values with mpnopovm.expectations(), which
     # uses mpnopovm.probability_map.
@@ -204,7 +205,7 @@ def test_mppovm_embed_expectation(
 
     # Test with an arbitrary random MPO instead of an MPDO
     mpo = mp.factory.random_mpa(nr_sites, local_dim2, bond_dim, rgen,
-                                normalized=True)
+                                dtype=np.complex_, normalized=True)
     mpo_red = next(mp.reductions_mpo(mpo, width, startsites=[startsite]))
     ept = mp.prune(full_povm.pmf(mpo, 'mpdo'), singletons=True).to_array()
     ept_red = red_povm.pmf(mpo_red, 'mpdo').to_array()
@@ -231,10 +232,10 @@ def test_mppovm_expectation_pure(nr_sites, width, local_dim, bond_dim, rgen):
 def test_mppovm_expectation_pmps(nr_sites, width, local_dim, bond_dim, rgen):
     paulis = povm.pauli_povm(local_dim)
     mppaulis = povm.MPPovm.from_local_povm(paulis, width)
-    psi = factory.random_mpa(nr_sites, (local_dim, local_dim), bond_dim,
-                             randstate=rgen)
-    rho = mpsmpo.pmps_to_mpo(psi)
-    expect_psi = list(mppaulis.expectations(psi, mode='pmps'))
+    pmps = factory.random_mpa(nr_sites, (local_dim, local_dim), bond_dim,
+                              dtype=np.complex_, randstate=rgen)
+    rho = mpsmpo.pmps_to_mpo(pmps)
+    expect_psi = list(mppaulis.expectations(pmps, mode='pmps'))
     expect_rho = list(mppaulis.expectations(rho))
 
     assert len(expect_psi) == len(expect_rho)
@@ -261,7 +262,7 @@ def test_mppovm_pmf_as_array_pmps(
         mppaulis = povm.MPPovm.from_local_povm(povm.pauli_povm(pdims), width)
     mppaulis = mppaulis.embed(nr_sites, startsite, pdims)
     pmps = factory.random_mpa(nr_sites, local_dim, bond_dim,
-                              randstate=rgen)
+                              dtype=np.complex_, randstate=rgen)
     pmps /= mp.norm(pmps)
     rho = mpsmpo.pmps_to_mpo(pmps)
     expect_rho = mppaulis.pmf_as_array(rho, 'mpdo')
@@ -281,7 +282,7 @@ def test_mppovm_pmf_as_array_pmps_benchmark(
     mpp_y = povm.MPPovm.from_local_povm(pauli_y, width) \
                        .embed(nr_sites, startsite, local_dim)
     pmps = factory.random_mpa(nr_sites, (local_dim, local_dim), bond_dim,
-                              randstate=rgen)
+                              dtype=np.complex_, randstate=rgen)
     pmps /= mp.norm(pmps)
     benchmark(lambda: mpp_y.pmf_as_array(pmps, 'pmps', impl=impl))
 


### PR DESCRIPTION
Switched the default dtype of random_mpa to np.float64 and used the opportunity to clean up the usage of some factory functions in the tests.